### PR TITLE
Do not allow interactive zypper

### DIFF
--- a/ci/packaging/suse/skuba-update_spec.tmpl
+++ b/ci/packaging/suse/skuba-update_spec.tmpl
@@ -28,7 +28,7 @@ Group:          System/Management
 Url:            https://github.com/SUSE/skuba-update
 Source0:        %{name}.tar.gz
 BuildRequires:  python3-setuptools
-Requires:       python3
+Requires:       python3-setuptools
 Requires:       zypper >= 1.14
 BuildArch:      noarch
 
@@ -41,12 +41,12 @@ __DESCRIPTION__
 %build
 
 %install
-python3 setup.py install --root %{buildroot}
+python3 setup.py install --root %{buildroot} --install-script %{_sbindir}
 
 %files
 %defattr(-,root,root)
 %license LICENSE
-%{_bindir}/%{name}
+%{_sbindir}/%{name}
 %{python3_sitelib}/*
 
 %changelog

--- a/skuba_update/skuba_update.py
+++ b/skuba_update/skuba_update.py
@@ -39,16 +39,18 @@ def main():
         raise Exception('root privileges are required to run this tool')
 
     run_zypper_command(['zypper', 'ref', '-s'])
-    run_zypper_command(
-        ['zypper', '--non-interactive-include-reboot-patches', 'patch']
-    )
+    run_zypper_command([
+        'zypper', '--non-interactive',
+        '--non-interactive-include-reboot-patches', 'patch'
+    ])
     code = run_zypper_command(
         ['zypper', '--non-interactive-include-reboot-patches', 'patch-check']
     )
     if are_patches_available(code):
-        run_zypper_command(
-            ['zypper', '--non-interactive-include-reboot-patches', 'patch']
-        )
+        run_zypper_command([
+            'zypper', '--non-interactive',
+            '--non-interactive-include-reboot-patches', 'patch'
+        ])
 
 
 def is_zypper_error(code):

--- a/test/skuba_update_test.py
+++ b/test/skuba_update_test.py
@@ -87,7 +87,8 @@ def test_main(mock_subprocess, mock_geteuid):
         call(['zypper', '--version'], stdout=ANY, stderr=ANY, env=ANY),
         call(['zypper', 'ref', '-s'], env=ANY),
         call([
-            'zypper', '--non-interactive-include-reboot-patches', 'patch'
+            'zypper', '--non-interactive',
+            '--non-interactive-include-reboot-patches', 'patch'
         ], env=ANY),
         call([
             'zypper', '--non-interactive-include-reboot-patches', 'patch-check'
@@ -109,13 +110,15 @@ def test_main_zypper_returns_100(mock_subprocess, mock_geteuid):
         call(['zypper', '--version'], stdout=ANY, stderr=ANY, env=ANY),
         call(['zypper', 'ref', '-s'], env=ANY),
         call([
-            'zypper', '--non-interactive-include-reboot-patches', 'patch'
+            'zypper', '--non-interactive',
+            '--non-interactive-include-reboot-patches', 'patch'
         ], env=ANY),
         call([
             'zypper', '--non-interactive-include-reboot-patches', 'patch-check'
         ], env=ANY),
         call([
-            'zypper', '--non-interactive-include-reboot-patches', 'patch'
+            'zypper', '--non-interactive',
+            '--non-interactive-include-reboot-patches', 'patch'
         ], env=ANY)
     ]
 


### PR DESCRIPTION
This PR is two fold:

1. **It forces zypper to be non-interactive:**
    Using the `--non-interactive-include-reboot-patches` does not assume `--non-interactive` flag.

2. **It adds the python3-setuptools dependency:**
    I realized this is required to run the auto-generated script installed in `/usr/sbin/skuba-update`