### PR TITLE
Add basic OS update testing logic

### DIFF
--- a/test/os/Makefile
+++ b/test/os/Makefile
@@ -1,0 +1,3 @@
+.PHONY: test-suse
+test-suse:
+	$(MAKE) -C suse test

--- a/test/os/suse/Dockerfile.builder
+++ b/test/os/suse/Dockerfile.builder
@@ -1,0 +1,4 @@
+FROM registry.opensuse.org/opensuse/tumbleweed
+
+RUN zypper ref && zypper -n in rpm-build rpmdevtools createrepo
+RUN rm /var/run/reboot-needed

--- a/test/os/suse/Makefile
+++ b/test/os/suse/Makefile
@@ -1,0 +1,59 @@
+MAKEFILE_PATH := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+
+OPENSUSE_LEAP_IMAGE = registry.opensuse.org/opensuse/leap
+OPENSUSE_TUMBLEWEED_IMAGE = registry.opensuse.org/opensuse/tumbleweed
+SLE_15_IMAGE = registry.suse.de/suse/sle-15-sp1/update/cr/images/suse/sle15:15.1
+BUILDER_IMAGE = opensuse/tumbleweed:build-rpm
+
+.PHONY: test
+test: repos test-opensuse test-sle
+
+.PHONY: test-opensuse
+test-opensuse: test-opensuse-tumbleweed test-opensuse-leap
+
+.PHONY: test-opensuse-tumbleweed
+test-opensuse-tumbleweed:
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(OPENSUSE_TUMBLEWEED_IMAGE) /suse/test-interruptive-updates.sh
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(OPENSUSE_TUMBLEWEED_IMAGE) /suse/test-non-interruptive-updates.sh
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(OPENSUSE_TUMBLEWEED_IMAGE) /suse/test-interruptive-updates-with-needreboot.sh
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(OPENSUSE_TUMBLEWEED_IMAGE) /suse/test-non-interruptive-updates-with-needreboot.sh
+
+.PHONY: test-opensuse-leap
+test-opensuse-leap:
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(OPENSUSE_LEAP_IMAGE) /suse/test-interruptive-updates.sh
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(OPENSUSE_LEAP_IMAGE) /suse/test-non-interruptive-updates.sh
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(OPENSUSE_LEAP_IMAGE) /suse/test-interruptive-updates-with-needreboot.sh
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(OPENSUSE_LEAP_IMAGE) /suse/test-non-interruptive-updates-with-needreboot.sh
+
+.PHONY: test-sle
+test-sle: test-sle-15
+
+.PHONY: test-sle-15
+test-sle-15:
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(SLE_15_IMAGE) /suse/test-interruptive-updates.sh
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(SLE_15_IMAGE) /suse/test-non-interruptive-updates.sh
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(SLE_15_IMAGE) /suse/test-interruptive-updates-with-needreboot.sh
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(SLE_15_IMAGE) /suse/test-non-interruptive-updates-with-needreboot.sh
+
+.PHONY: rpm-builder-image
+rpm-builder-image:
+	docker build -t $(BUILDER_IMAGE) -f Dockerfile.builder .
+
+.PHONY: rpms
+rpms: artifacts/caasp-test-1-1.noarch.rpm artifacts/caasp-test-2-1.noarch.rpm
+
+artifacts/%.rpm: rpm-builder-image
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(BUILDER_IMAGE) /suse/build-rpm.sh $*
+
+.PHONY: repos
+repos: rpms artifacts/repo-base artifacts/repo-update-with-reboot-suggested artifacts/repo-update-without-reboot-suggested
+
+artifacts/repo-%:
+	docker run --rm -v $(MAKEFILE_PATH):/suse -it $(BUILDER_IMAGE) /suse/build-repo.sh $*
+
+.PHONY: clean
+clean:
+	rm -rf artifacts/base-repo
+	rm -rf artifacts/update-repo-with-reboot-suggested
+	rm -rf artifacts/update-repo-without-reboot-suggested
+	rm -f artifacts/*.rpm

--- a/test/os/suse/artifacts/.gitignore
+++ b/test/os/suse/artifacts/.gitignore
@@ -1,0 +1,2 @@
+*.rpm
+repos/

--- a/test/os/suse/build-repo.sh
+++ b/test/os/suse/build-repo.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 SUSE LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "$(dirname "$0")/suse_build.sh"
+
+REPONAME=$1
+REPODIR=/suse/artifacts/repos
+REPOPATH=$REPODIR/$1
+
+mkdir -p "$REPOPATH"
+
+populate_repo() {
+    case "$REPONAME" in
+        base)
+            cp /suse/artifacts/caasp-test-1-1.noarch.rpm "$REPOPATH"
+            ;;
+        update-with-reboot-suggested)
+            cp /suse/artifacts/caasp-test-2-1.noarch.rpm "$REPOPATH"
+            ;;
+        update-without-reboot-suggested)
+            cp /suse/artifacts/caasp-test-2-1.noarch.rpm "$REPOPATH"
+            ;;
+        *)
+            echo "unknown repo ($REPONAME) requested"
+            exit 1
+    esac
+}
+
+initialize_repo() {
+    createrepo --update "$REPOPATH"
+}
+
+add_erratum_to_repository() {
+    cp /suse/"$REPONAME".xml "$REPOPATH"/repodata/updateinfo.xml
+    updateinfosha256=$(sha256sum "$REPOPATH"/repodata/updateinfo.xml | awk '{print $1}')
+    updateinfosize=$(du -b "$REPOPATH"/repodata/updateinfo.xml | awk '{print $1}')
+    gzip "$REPOPATH"/repodata/updateinfo.xml
+    updateinfosha256gz=$(sha256sum "$REPOPATH"/repodata/updateinfo.xml.gz | awk '{print $1}')
+    updateinfosizegz=$(du -b "$REPOPATH"/repodata/updateinfo.xml.gz | awk '{print $1}')
+    mv "$REPOPATH"/repodata/updateinfo.xml.gz "$REPOPATH"/repodata/"$updateinfosha256gz"-updateinfo.xml.gz
+    repodata=$(head -n-1 "$REPOPATH"/repodata/repomd.xml)
+    echo "$repodata" > "$REPOPATH"/repodata/repomd.xml
+    cat <<EOF >> "$REPOPATH"/repodata/repomd.xml
+<data type="updateinfo">
+  <checksum type="sha256">$updateinfosha256gz</checksum>
+  <open-checksum type="sha256">$updateinfosha256</open-checksum>
+  <location href="repodata/$updateinfosha256gz-updateinfo.xml.gz"/>
+  <timestamp>$(date +%s)</timestamp>
+  <size>$updateinfosizegz</size>
+  <open-size>$updateinfosize</open-size>
+</data>
+</repomd>
+EOF
+}
+
+populate_repo
+initialize_repo
+
+case "$REPONAME" in
+    update-*)
+        add_erratum_to_repository
+    ;;
+esac

--- a/test/os/suse/build-rpm.sh
+++ b/test/os/suse/build-rpm.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 SUSE LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "$(dirname "$0")/suse_build.sh"
+
+build_init
+
+build_package "$1"
+
+copy_packages

--- a/test/os/suse/caasp-test-1-1.noarch.spec
+++ b/test/os/suse/caasp-test-1-1.noarch.spec
@@ -1,0 +1,38 @@
+# Copyright (c) 2019 SUSE LLC. All rights reserved.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+Name:      caasp-test
+Version:   1
+Release:   1
+Summary:   CaaSP test package
+License:   Apache-2.0
+BuildArch: noarch
+
+%description
+CaaSP test package
+
+%prep
+# nothing to be done
+
+%build
+cat > caasp-test <<EOF
+#!/usr/bin/env bash
+echo CaaSP test version %{version}
+EOF
+
+%install
+mkdir -p %{buildroot}/usr/bin/
+install -m 755 caasp-test %{buildroot}/usr/bin/caasp-test
+
+%files
+/usr/bin/caasp-test
+
+%changelog

--- a/test/os/suse/caasp-test-2-1.noarch.spec
+++ b/test/os/suse/caasp-test-2-1.noarch.spec
@@ -1,0 +1,38 @@
+# Copyright (c) 2019 SUSE LLC. All rights reserved.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+Name:      caasp-test
+Version:   2
+Release:   1
+Summary:   CaaSP test package
+License:   Apache-2.0
+BuildArch: noarch
+
+%description
+CaaSP test package
+
+%prep
+# nothing to be done
+
+%build
+cat > caasp-test <<EOF
+#!/usr/bin/env bash
+echo CaaSP test version %{version}
+EOF
+
+%install
+mkdir -p %{buildroot}/usr/bin/
+install -m 755 caasp-test %{buildroot}/usr/bin/caasp-test
+
+%files
+/usr/bin/caasp-test
+
+%changelog

--- a/test/os/suse/suse.sh
+++ b/test/os/suse/suse.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 SUSE LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xe
+
+add_package_to_need_reboot() {
+    echo "$1" >> /etc/zypp/needreboot.d/"$1"
+}
+
+add_repository() {
+    zypper ar -f --no-gpgcheck "/suse/artifacts/repos/$1" "$1"
+}
+
+refresh_repository() {
+    zypper ref -f -r "$1"
+}
+
+install_package() {
+    zypper -n in -r "${1:-base}" "${2:-caasp-test}"
+}
+
+zypper_patch() {
+    zypper --no-refresh --non-interactive-include-reboot-patches patch -r "$1" -y
+}
+
+check_test_package_version() {
+    caasp-test | grep "CaaSP test version $1"
+}
+
+check_reboot_needed_present() {
+    [ -f /var/run/reboot-needed ]
+}
+
+check_reboot_needed_absent() {
+    [ ! -f /var/run/reboot-needed ]
+}

--- a/test/os/suse/suse_build.sh
+++ b/test/os/suse/suse_build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 SUSE LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xe
+
+RPMBUILD=/root/rpmbuild
+PACKAGEDIR=/suse
+OUTPUTDIR=/suse/artifacts
+
+build_init() {
+    rpm_setuptree
+}
+
+rpm_setuptree() {
+    rpmdev-setuptree
+}
+
+build_package() {
+    rpmbuild -ba $PACKAGEDIR/"${1:-caasp-test-1-1.noarch}".spec
+}
+
+copy_packages() {
+    find $RPMBUILD/RPMS -type f -name "*.rpm" -exec cp {} $OUTPUTDIR \;
+}

--- a/test/os/suse/test-interruptive-updates-with-needreboot.sh
+++ b/test/os/suse/test-interruptive-updates-with-needreboot.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 SUSE LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Interruptive updates are those that are reported as a reboot suggested in the
+# update metadata. Zypper will flag a 102 return code in this case, and will
+# write the /var/run/reboot-needed sentinel file.
+
+source "$(dirname "$0")/suse.sh"
+
+add_repository "base"
+install_package "base" "caasp-test"
+
+check_test_package_version "1"
+
+add_package_to_need_reboot "caasp-test"
+
+add_repository "update-with-reboot-suggested"
+set +e
+zypper_patch "update-with-reboot-suggested"
+zypper_retval=$?
+set -e
+
+if [[ $zypper_retval -ne 102 ]]; then
+    echo "unexpected return value ($zypper_retval) from zypper patch (expected ZYPPER_EXIT_INF_REBOOT_NEEDED: 102)"
+    exit 1
+fi
+
+check_test_package_version "2"
+check_reboot_needed_present

--- a/test/os/suse/test-interruptive-updates.sh
+++ b/test/os/suse/test-interruptive-updates.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 SUSE LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Interruptive updates are those that are reported as a reboot suggested in the
+# update metadata. Zypper will flag a 102 return code in this case, but will not
+# write the /var/run/reboot-needed sentinel file.
+
+source "$(dirname "$0")/suse.sh"
+
+add_repository "base"
+install_package "base" "caasp-test"
+
+check_test_package_version "1"
+
+add_repository "update-with-reboot-suggested"
+set +e
+zypper_patch "update-with-reboot-suggested"
+zypper_retval=$?
+set -e
+
+if [[ $zypper_retval -ne 102 ]]; then
+    echo "unexpected return value ($zypper_retval) from zypper patch (expected ZYPPER_EXIT_INF_REBOOT_NEEDED: 102)"
+    exit 1
+fi
+
+check_test_package_version "2"
+check_reboot_needed_absent

--- a/test/os/suse/test-non-interruptive-updates-with-needreboot.sh
+++ b/test/os/suse/test-non-interruptive-updates-with-needreboot.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 SUSE LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Non-interruptive updates are those that are not reported as a reboot suggested in the
+# update metadata. Zypper will flag a 0 return code in this case, and will
+# write the /var/run/reboot-needed sentinel file.
+
+source "$(dirname "$0")/suse.sh"
+
+add_repository "base"
+install_package "base" "caasp-test"
+
+check_test_package_version "1"
+
+add_package_to_need_reboot "caasp-test"
+
+add_repository "update-without-reboot-suggested"
+zypper_patch "update-without-reboot-suggested"
+
+check_test_package_version "2"
+check_reboot_needed_present

--- a/test/os/suse/test-non-interruptive-updates.sh
+++ b/test/os/suse/test-non-interruptive-updates.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 SUSE LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Non-interruptive updates are those that are not reported as a reboot suggested in the
+# update metadata. Zypper will flag a 0 return code in this case, and will not
+# write the /var/run/reboot-needed sentinel file.
+
+source "$(dirname "$0")/suse.sh"
+
+add_repository "base"
+install_package "base" "caasp-test"
+
+check_test_package_version "1"
+
+add_repository "update-without-reboot-suggested"
+zypper_patch "update-without-reboot-suggested"
+
+check_test_package_version "2"
+check_reboot_needed_absent

--- a/test/os/suse/update-with-reboot-suggested.xml
+++ b/test/os/suse/update-with-reboot-suggested.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+  <update from="caasp-team@suse.de" status="stable" type="recommended" version="1">
+    <id>SUSE-2019-0</id>
+    <title>An update</title>
+    <severity>moderate</severity>
+    <release>SUSE SLE-15-SP1 Update</release>
+    <issued date="1558700214"/>
+    <description>An update</description>
+    <pkglist>
+      <collection>
+        <name>An update</name>
+        <package arch="noarch" epoch="0" name="caasp-test" release="1" src="caasp-test-2-1.noarch.rpm" version="2">
+          <filename>caasp-test-2-1.noarch.rpm</filename>
+          <reboot_suggested>True</reboot_suggested>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
+</updates>

--- a/test/os/suse/update-without-reboot-suggested.xml
+++ b/test/os/suse/update-without-reboot-suggested.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+  <update from="caasp-team@suse.de" status="stable" type="recommended" version="1">
+    <id>SUSE-2019-0</id>
+    <title>An update</title>
+    <severity>moderate</severity>
+    <release>SUSE SLE-15-SP1 Update</release>
+    <issued date="1558700214"/>
+    <description>An update</description>
+    <pkglist>
+      <collection>
+        <name>An update</name>
+        <package arch="noarch" epoch="0" name="caasp-test" release="1" src="caasp-test-2-1.noarch.rpm" version="2">
+          <filename>caasp-test-2-1.noarch.rpm</filename>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
+</updates>

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
 [testenv]
 whitelist_externals =
     /bin/bash
+    /sbin/bash
 basepython =
     check: python
     py36: python3.6
@@ -65,4 +66,4 @@ setenv =
 commands =
     flake8 --statistics -j auto --count {toxinidir}/skuba_update
     flake8 --statistics -j auto --count {toxinidir}/test
-    bash -c 'shellcheck -e SC1117 {toxinidir}/ci/packaging/suse/rpmfiles_maker.sh'
+    bash -c 'find . -name "*.sh" -exec shellcheck -e SC1090 \{\} \;'


### PR DESCRIPTION
This adds tests that ensure that zypper behaves as we expect. The
test cases are currently opensuse/leap, opensuse/tumbleweed and
SLE15.

All tests are performed using containers.

First, a container is built to generate RPM's of a package called
`caasp-test` with two versions: 1 and 2. Then, three different
repositories are created inside `artifacts/repos`: `base`,
`update-with-reboot-suggested` and `update-without-reboot-suggested`.

* `base` repository: contains the version 1 of the `caasp-test` package.
* `update-without-reboot-suggested` repository: contains the version 2 of
  the `caasp-test` package, with an `updateinfo.xml` that indicates that no
  reboot is suggested when this patch is applied.
* `update-with-reboot-suggested` repository: same as before, only that the
  `updateinfo.xml` file indicates that a reboot is suggested when applying
  this patch.

Tests have been added both for checking the interruptive update behavior as
well as the non-interruptive behavior.

Tests have been added both for checking the interruptive update behavior as
well as the non-interruptive behavior, both in the cases when the
package is in the `/etc/zypp/neereboot.d` list and when it's not.